### PR TITLE
Compatibility fixes for unprivileged `gradle` user (#2)

### DIFF
--- a/28/Dockerfile
+++ b/28/Dockerfile
@@ -37,7 +37,8 @@ RUN mkdir /root/.android \
     "tools" \
     "extras;android;m2repository" \
     "extras;google;m2repository" \
-    "extras;google;google_play_services"
+    "extras;google;google_play_services" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 # Install Kotlin
 RUN curl "https://get.sdkman.io" -o sdkman.sh \

--- a/28/ndk20/Dockerfile
+++ b/28/ndk20/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/28/ndk21/Dockerfile
+++ b/28/ndk21/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/29/Dockerfile
+++ b/29/Dockerfile
@@ -36,7 +36,8 @@ RUN mkdir /root/.android \
     "extras;google;m2repository" \
     "extras;google;google_play_services" \
  && sdkmanager --uninstall \
-    "emulator"
+    "emulator" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 # Install Kotlin
 RUN curl "https://get.sdkman.io" -o sdkman.sh \

--- a/29/ndk20/Dockerfile
+++ b/29/ndk20/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/29/ndk21/Dockerfile
+++ b/29/ndk21/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/30/Dockerfile
+++ b/30/Dockerfile
@@ -35,7 +35,8 @@ RUN mkdir /root/.android \
     "extras;google;m2repository" \
     "extras;google;google_play_services" \
  && sdkmanager --uninstall \
-    "emulator"
+    "emulator" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 # Install Kotlin
 RUN curl "https://get.sdkman.io" -o sdkman.sh \

--- a/30/ndk21/Dockerfile
+++ b/30/ndk21/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/31/Dockerfile
+++ b/31/Dockerfile
@@ -35,7 +35,8 @@ RUN mkdir /root/.android \
     "extras;google;m2repository" \
     "extras;google;google_play_services" \
  && sdkmanager --uninstall \
-    "emulator"
+    "emulator" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 # Install Kotlin
 RUN curl "https://get.sdkman.io" -o sdkman.sh \

--- a/31/ndk21/Dockerfile
+++ b/31/ndk21/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/31/ndk22/Dockerfile
+++ b/31/ndk22/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/32/Dockerfile
+++ b/32/Dockerfile
@@ -33,7 +33,8 @@ RUN mkdir /root/.android \
     "extras;google;m2repository" \
     "extras;google;google_play_services" \
  && sdkmanager --uninstall \
-    "emulator"
+    "emulator" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 # Install Kotlin
 RUN curl "https://get.sdkman.io" -o sdkman.sh \

--- a/32/ndk23/Dockerfile
+++ b/32/ndk23/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/32/ndk24/Dockerfile
+++ b/32/ndk24/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/33/Dockerfile
+++ b/33/Dockerfile
@@ -33,7 +33,8 @@ RUN mkdir /root/.android \
     "extras;google;m2repository" \
     "extras;google;google_play_services" \
  && sdkmanager --uninstall \
-    "emulator"
+    "emulator" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 # Install Kotlin
 RUN curl "https://get.sdkman.io" -o sdkman.sh \

--- a/33/ndk25/Dockerfile
+++ b/33/ndk25/Dockerfile
@@ -6,6 +6,7 @@ ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
 USER root
 
 # Install the NDK
-RUN sdkmanager "ndk;$ANDROID_NDK_VERSION"
+RUN sdkmanager "ndk;$ANDROID_NDK_VERSION" \
+ && chown -vR gradle:gradle /opt/android-sdk
 
 USER gradle

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The main software that is added to the non-NDK versions:
 
 The sdkmanager packages that are installed are generally the current version and the previous version.  Check the Dockerfile for more details.
 
-**Note:** From February 7th 2024, the build images are running as the unprivileged `gradle` user instead of `root`, if you encounter a build error saying "_Failed to install the following SDK components: ..._" then it means that the image is missing a component required by your Android build; send a PR to add this dependency or select another another container image.
+**Note:** From February 7th 2024, the build images are running as the unprivileged `gradle` user instead of `root`, if you encounter permission problems due to this change, send a PR to add the dependency you need or select a image variant that already have it included.
 
 ## Examples
 Run the following command in your Android project.  The directory should be same as your `build.gradle` file.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ The main software that is added to the non-NDK versions:
 
 The sdkmanager packages that are installed are generally the current version and the previous version.  Check the Dockerfile for more details.
 
-**Note:** From February 7th 2024, the build images are running as the unprivileged `gradle` user instead of `root`, if you encounter permission problems due to this change, send a PR to add the dependency you need or select a image variant that already have it included.
-
 ## Examples
 Run the following command in your Android project.  The directory should be same as your `build.gradle` file.
 ```


### PR DESCRIPTION
This change fixes up the changes from #3 that came across as a bit too restrictive, in retrospect. In order to support smooth software lifecycle management, it needs to be possible to install additional SDK components, e.g. transitioning from `build-tools:30.0.1` to `build-tools:30.0.3`. It is not desirable to force a synchronized bump on all current git branches at the same time.

Ping @j-vilela FYI!