### PR TITLE
Remove `patcher;v4` SDK component from `android:28`

### DIFF
--- a/28/Dockerfile
+++ b/28/Dockerfile
@@ -33,7 +33,6 @@ RUN mkdir /root/.android \
     "build-tools;28.0.1" \
     "build-tools;28.0.0" \
     "build-tools;27.0.3" \
-    "patcher;v4" \
     "tools" \
     "extras;android;m2repository" \
     "extras;google;m2repository" \


### PR DESCRIPTION
The "patcher" component is no longer available, this causes Docker build to fail with message _"Failed to find package patcher"_.